### PR TITLE
Floor size

### DIFF
--- a/app/controllers/api/v1/partners_controller.rb
+++ b/app/controllers/api/v1/partners_controller.rb
@@ -20,6 +20,7 @@ class Api::V1::PartnersController < ApplicationController
       partners = Partner.select_with_distance_from_home(customer_request.lat, customer_request.lng)
                         .with_expertise(customer_request.material)
                         .within_radius(customer_request.lat, customer_request.lng)
+                        .within_area(customer_request.area)
                         .order_by_rating
                         .order_by_distance_from_home
       render json: partners.to_json, status: 200

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -4,6 +4,7 @@ class Partner < ApplicationRecord
   MATERIALS = %w[wood carpet tiles]
 
   validate :validate_materials
+  validate :min_is_less_than_max
 
   scope :within_radius, -> (lat, lng) { where("acos(sin(lat) * sin(?) + cos(lat) * cos(?) * cos(lng - ?)) * 6371 <= radius", lat, lat, lng) }
   scope :with_expertise, -> (expertise) { where('?=ANY(materials)', expertise) }
@@ -31,6 +32,10 @@ class Partner < ApplicationRecord
         errors.add(:materials_list, material + " is an unknown material")
       end
     end
+  end
+
+  def min_is_less_than_max
+    errors.add(:min_area, "can't be greater than max_area") if min_area > max_area
   end
 
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -7,6 +7,7 @@ class Partner < ApplicationRecord
 
   scope :within_radius, -> (lat, lng) { where("acos(sin(lat) * sin(?) + cos(lat) * cos(?) * cos(lng - ?)) * 6371 <= radius", lat, lat, lng) }
   scope :with_expertise, -> (expertise) { where('?=ANY(materials)', expertise) }
+  scope :within_area, -> (area) { where("min_area <= ? AND max_area >= ?", area, area) }
 
   scope :order_by_rating, -> { order(rating: :desc) }
   scope :order_by_distance_from_home, -> { order(:distance) }

--- a/db/migrate/20210225100206_add_area_ranges_to_partner.rb
+++ b/db/migrate/20210225100206_add_area_ranges_to_partner.rb
@@ -1,0 +1,6 @@
+class AddAreaRangesToPartner < ActiveRecord::Migration[6.0]
+  def change
+    add_column :partners, :min_area, :integer
+    add_column :partners, :max_area, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_13_111939) do
+ActiveRecord::Schema.define(version: 2021_02_25_100206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,8 @@ ActiveRecord::Schema.define(version: 2021_02_13_111939) do
     t.float "rating"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "min_area"
+    t.integer "max_area"
   end
 
 end

--- a/test/controllers/api/v1/partners_controller_test.rb
+++ b/test/controllers/api/v1/partners_controller_test.rb
@@ -40,9 +40,10 @@ class Api::V1::PartnersControllerTest < ActionDispatch::IntegrationTest
       let (:partner3) { create(:partner, lat: 13.023111, lng: 79.881900, radius: 100, materials: ['carpet', 'wood'], rating: 4) }
       let (:partner4) { create(:partner, lat: 39.013111, lng: 19.891900, radius: 100, materials: ['tiles']) }
       let (:partner5) { create(:partner, lat: 13.016111, lng: 79.861900, radius: 200, materials: ['carpet'], rating: 5) }
+      let (:partner6) { create(:partner, lat: 13.016111, lng: 79.861900, radius: 200, materials: ['carpet'], min_area: 100, max_area: 1000) }
 
       it 'should return all the partners matching the customer request in order, first by rating and then by distance' do
-        partner1; partner2; partner3; partner4; partner5
+        partner1; partner2; partner3; partner4; partner5; partner6
         get "#{url}/match/#{customer_request.id}"
 
         json = JSON.parse(@response.body)

--- a/test/controllers/api/v1/partners_controller_test.rb
+++ b/test/controllers/api/v1/partners_controller_test.rb
@@ -47,6 +47,7 @@ class Api::V1::PartnersControllerTest < ActionDispatch::IntegrationTest
 
         json = JSON.parse(@response.body)
         assert_response :success
+        assert_equal 3, json.count
         assert_equal [partner5.id, partner3.id, partner2.id], [json[0]['id'], json[1]['id'], json[2]['id']]
       end
 

--- a/test/factories/partners.rb
+++ b/test/factories/partners.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     end
     lat { 13.012111 }
     lng { 79.899900 }
+    min_area { 100 }
+    max_area { 200 }
     radius { 10 }
     rating { 4 }
   end

--- a/test/factories/partners.rb
+++ b/test/factories/partners.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     end
     lat { 13.012111 }
     lng { 79.899900 }
-    min_area { 100 }
-    max_area { 200 }
+    min_area { 5 }
+    max_area { 20 }
     radius { 10 }
     rating { 4 }
   end

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -20,6 +20,12 @@ describe Partner do
         create(:partner, materials: ['abc'])
       end
     end
+
+    it "does not create a partner with an invalid area range" do
+      assert_raises ActiveRecord::RecordInvalid do
+        create(:partner, min_area: 10, max_area: 5)
+      end
+    end
   end
 
   describe 'scopes' do

--- a/test/models/partner_test.rb
+++ b/test/models/partner_test.rb
@@ -37,6 +37,21 @@ describe Partner do
       end
     end
 
+    describe 'within floor area range' do
+      let(:partner1) { create(:partner, min_area: 5, max_area: 8) }
+      let(:partner2) { create(:partner, min_area: 5, max_area: 20) }
+      let(:partner3) { create(:partner, min_area: 10, max_area: 100) }
+      let(:partner4) { create(:partner, min_area: 5, max_area: 10) }
+      let(:partner5) { create(:partner, min_area: 50, max_area: 100) }
+
+      it 'should return only partners within  a specific expertise' do
+        partner1; partner2; partner3; partner4; partner5
+        partners = Partner.within_area(10)
+        assert_equal 3, partners.size
+        assert_equal [partner2.id, partner3.id, partner4.id].sort, [partners.first.id, partners.second.id, partners.last.id].sort
+      end
+    end
+
     describe 'distance' do
       let (:lat) { 13.013111 }
       let (:lng) { 79.891900 }


### PR DESCRIPTION

**Background**
The matching implementation in Assignment: Matching Customer & Partner is a great success and our customers are very happy with it. But our Partners gave us some feedback that they would like to restrict the customers they receive based on floor size: Some complained that small floor sizes are not worth their time, while others said that they can’t handle big flooring projects with their limited staff.

**User Story**
As a craftsman I want to be able to set a preference for the floor size, so that I only receive flooring projects of certain sizes that fit my company.

**Acceptance Criteria**
The partner data has an additional setting for floor size
Floor size range (one continuous range, e.g. 50 - 100 square meters)
Matching a customer and partner should additionally happen on the following criteria:
The requested floor size should be within the range set by the partner

**Implementation**
We added 2 new fields (min_area, max_area) range on the partner and scope `within_area` to be used for enhancing the matching with this new filtering.

